### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,15 @@ cd DeepSeek-V3/inference
 pip install -r requirements.txt
 ```
 
+Alternatively, if you are running in a Codex environment with network
+access, use the provided helper script from the repository root to
+create a virtual environment and install all dependencies automatically:
+
+```shell
+cd DeepSeek-V3
+./setup.sh
+```
+
 Download the model weights from Hugging Face, and put them into `/path/to/DeepSeek-V3` folder.
 
 #### Model Weights Conversion

--- a/inference/model.py
+++ b/inference/model.py
@@ -185,7 +185,7 @@ class Linear(nn.Module):
         else:
             self.register_parameter("scale", None)
         if bias:
-            self.bias = nn.Parameter(torch.empty(self.part_out_features))
+            self.bias = nn.Parameter(torch.empty(out_features, dtype=dtype or Linear.dtype))
         else:
             self.register_parameter("bias", None)
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Setup script for installing Solomon dependencies
+# Requires internet access to download Python packages
+set -euo pipefail
+
+# Optionally install system packages
+if command -v apt-get &>/dev/null; then
+    sudo apt-get update
+    sudo apt-get install -y python3-venv python3-pip build-essential git
+fi
+
+# Create a virtual environment in .venv
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+# Install Python dependencies for inference
+pip install -r inference/requirements.txt
+
+echo "Environment setup complete"


### PR DESCRIPTION
## Summary
- avoid undefined attribute in `Linear.__init__` when bias is enabled
- add helper script to install dependencies with internet access
- document using `setup.sh` in README

## Testing
- `python -m py_compile inference/model.py`
- `python -m py_compile inference/generate.py inference/convert.py inference/fp8_cast_bf16.py`


------
https://chatgpt.com/codex/tasks/task_e_6851f87119d4832fbb9671c244078c16